### PR TITLE
[chore] v0.2.0リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-17
+
+### Added
+
+- resultMapのtype/resultType/parameterType属性のFQN値からJavaクラスへのジャンプ機能
+- CodeLensに「Go to Type Class」リンクを表示
+- resultMap属性値からresultMap定義へのジャンプ機能（association/collectionにも対応）
+- `<include refid="...">` から同一XML内の `<sql id="...">` へのジャンプ機能
+- ofType/javaType属性からJavaクラスへのジャンプに対応
+
+### Changed
+
+- 属性値検出ロジックを共通ヘルパーに統合しコードを簡素化
+- CodeLensのJavaクラス検索を並列実行に改善
+- デモGIFをパッケージから除外してvsixファイルサイズを削減
+
 ## [0.1.2] - 2026-02-08
 
 ### Added
@@ -62,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@Param`アノテーション付き引数を持つメソッドの検出対応
 - 複数行にまたがるXMLタグ定義の検出対応
 
-[Unreleased]: https://github.com/s-41/mybatis-bridge/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/s-41/mybatis-bridge/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/s-41/mybatis-bridge/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/s-41/mybatis-bridge/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/s-41/mybatis-bridge/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/s-41/mybatis-bridge/compare/v0.0.1...v0.1.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybatis-bridge",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "SAKASHIN",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## 目的・背景

v0.2.0のリリース準備。package.jsonのバージョン更新とCHANGELOGの追記。

## 変更内容

- `package.json` のバージョンを 0.1.2 → 0.2.0 に更新
- `CHANGELOG.md` に v0.2.0 のエントリを追加

## v0.2.0 の主な変更点

- resultMapのtype/resultType/parameterType属性からJavaクラスへのジャンプ機能
- resultMap属性値からresultMap定義へのジャンプ機能
- `<include refid="...">` から `<sql id="...">` へのジャンプ機能
- ofType/javaType属性からJavaクラスへのジャンプに対応
- 属性値検出ロジックの共通化とCodeLensの並列化

## 動作確認

- [x] `pnpm run compile` 成功
- [x] `vsce package` 成功
- [x] Marketplaceにパブリッシュ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)